### PR TITLE
get rid of exported utility methods

### DIFF
--- a/lib/record-sink.js
+++ b/lib/record-sink.js
@@ -27,7 +27,7 @@ WithNewLine = through.ctor({objectMode: true}, function (obj, enc, done) {
 defaultWrite = new WithNewLine()
 defaultWrite.pipe(process.stderr)
 
-// Constructor for a sink object that couple a write function and a format
+// Constructor for a sink object that couples a write stream and a format
 // function. A sink may also have a log level associated that is inspected by
 // the log methods. If the sink defines a `reset` function it will be called to
 // indicated that any associated file streams etc should be reopened.

--- a/lib/record-sink.js
+++ b/lib/record-sink.js
@@ -2,59 +2,13 @@ var stream = require('readable-stream')
   , assign = require('object-assign')
   , through = require('through2')
   , inherits = require('util').inherits
+  , createFormatter = require('dullstring')
   , defaultFormat
   , defaultWrite
   , WithNewLine
 
 // # Exports
-exports.Sink = Sink
-exports.createFormatter = createFormatter
-exports.writableStream = writableStream
-
-// # Formatter
-
-// Create a formatter function from pattern string
-function createFormatter(pattern) {
-  var tokens = pattern.split(/(:[a-zA-Z]+)/)
-
-  return function format(record) {
-    return tokens.map(function (token) {
-      // if it's not a placeholder return the token right away
-      if (token[0] !== ':') {
-        return token
-      }
-
-      // grab the value from the record, if it is a function call it
-      // and then coerce it all to a string
-      var val = record[token.substr(1)]
-
-      if (val && val.call) {
-        val = val.call(record)
-      }
-
-      return val !== void 0 ? '' + val : '-'
-    }).join('')
-  }
-}
-
-// # writableStream
-
-// A helper to create a write a stream from a function
-function writableStream(options, write) {
-  function Writable (override) {
-    if (!(this instanceof Writable)) {
-      return new Writable()
-    }
-    this.options = assign({}, options, override)
-    stream.Writable.call(this, this.options)
-  }
-
-  inherits(Writable, stream.Writable)
-
-  Writable.prototype._write = write
-
-  return Writable
-}
+module.exports = Sink
 
 // Default formatter used by sinks when nothing else is specified that tries
 // to provide a human friendly format that contains most information without

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/keis/record-sink.git"
   },
   "dependencies": {
+    "dullstring": "^1.0.1",
     "object-assign": "^3.0.0",
     "readable-stream": "^1.0.33",
     "standard-levels": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "istanbul": "^0.3.13",
     "matcha": "^0.6.0",
     "mocha": "^2.2.4",
-    "sinon": "^1.14.1"
+    "sinon": "^1.14.1",
+    "terminus": "^1.0.12"
   },
   "scripts": {
     "lint": "eslint lib test && coffeelint test",

--- a/test/unit/test.sink.coffee
+++ b/test/unit/test.sink.coffee
@@ -1,7 +1,6 @@
-sinks = require '../../lib/record-sink'
 
 describe "Sink", ->
-  {Sink} = sinks
+  Sink = require '../../lib/record-sink'
 
   it "accepts level as symbolic name", ->
     sink = new Sink null, null, 'ERROR'

--- a/test/unit/test.sink.coffee
+++ b/test/unit/test.sink.coffee
@@ -1,3 +1,12 @@
+terminus = require 'terminus'
+
+capture = ->
+  chunks = []
+  stream = terminus (chunk, enc, callback) ->
+    chunks.push chunk.toString()
+    callback()
+  {chunks, stream}
+
 
 describe "Sink", ->
   Sink = require '../../lib/record-sink'
@@ -17,3 +26,21 @@ describe "Sink", ->
       sink = new Sink null, null, 30
       sink.setLevel 'DEBUG'
       assert.equal sink.level, 10
+
+  describe "write", ->
+    it "transforms record before writing to stream", (done) ->
+      {chunks, stream} = capture()
+
+      record =
+        date: 'Date'
+        time: 'Time'
+        levelName:'INFO'
+        message: 'The message'
+
+      sink = new Sink stream, null, 'INFO'
+      sink.write record
+      setImmediate ->
+        assert.deepEqual chunks, [
+          '[Date Time] - INFO - The message'
+        ]
+        done()


### PR DESCRIPTION
Any use of `createFormatter` can be directly replaced by using the
`dullstring` module. `writableStream` can be replaced with the
`terminus` module but the usage is not identical.

Fixes #2
